### PR TITLE
Updated the item and equip table in battle screens

### DIFF
--- a/step-strikers-app/step-strikers-app/Battle Screens/BattleRollViewController.swift
+++ b/step-strikers-app/step-strikers-app/Battle Screens/BattleRollViewController.swift
@@ -167,6 +167,7 @@ class BattleRollViewController: UIViewController, UITableViewDataSource, UITable
         view.addSubview(dice2)
         
         performBattleAction(rollValue: rollValue, rollValueToBeat: rollValueToBeat)
+        endTurn(game: game, player: localCharacter.userName)
     }
     
     @objc func continuePressed(sender: UIButton!) {

--- a/step-strikers-app/step-strikers-app/Battle Screens/BattleSelectEquipViewController.swift
+++ b/step-strikers-app/step-strikers-app/Battle Screens/BattleSelectEquipViewController.swift
@@ -155,16 +155,27 @@ class BattleSelectEquipViewController: UIViewController, UITableViewDataSource, 
     
     // TODO: change this array based on actual player data
     func createEquipArray() {
-        equips.append(Equip(name: "one", quantity: "x5"))
-        equips.append(Equip(name: "two", quantity: "x5"))
-        equips.append(Equip(name: "three", quantity: "x5"))
-        equips.append(Equip(name: "four", quantity: "x5"))
-        equips.append(Equip(name: "five", quantity: "x5"))
-        equips.append(Equip(name: "six", quantity: "x5"))
-        equips.append(Equip(name: "seven", quantity: "x5"))
-        equips.append(Equip(name: "eight", quantity: "x5"))
-        equips.append(Equip(name: "nine", quantity: "x5"))
-        equips.append(Equip(name: "ten", quantity: "x5"))
+        let weaponsArr = localCharacter.weaponsInInventory
+        var quantities = localCharacter.inventoryQuantities
+        for weapon in weaponsArr {
+            if quantities.keys.contains(weapon.name) {
+                print(weapon.name)
+                print(quantities[weapon.name])
+                equips.append(Equip(name: weapon.name, quantity: "x\(quantities[weapon.name]!)"))
+                quantities.removeValue(forKey: weapon.name)
+            }
+        }
+        
+        let armorArr = localCharacter.armorInInventory
+        for armor in armorArr {
+            if quantities.keys.contains(armor.name) {
+                print(armor.name)
+                print(quantities[armor.name])
+                equips.append(Equip(name: armor.name, quantity: "x\(quantities[armor.name]!)"))
+                quantities.removeValue(forKey: armor.name)
+            }
+        }
+        
     }
     
     func createStatsArray() {

--- a/step-strikers-app/step-strikers-app/Battle Screens/BattleSelectItemViewController.swift
+++ b/step-strikers-app/step-strikers-app/Battle Screens/BattleSelectItemViewController.swift
@@ -164,16 +164,16 @@ class BattleSelectItemViewController: UIViewController, UITableViewDataSource, U
 
     // TODO: Update with actual item data
     func createItemArray() {
-        items.append(Items(name: "one", quantity: "x5"))
-        items.append(Items(name: "two", quantity: "x5"))
-        items.append(Items(name: "three", quantity: "x5"))
-        items.append(Items(name: "four", quantity: "x5"))
-        items.append(Items(name: "five", quantity: "x5"))
-        items.append(Items(name: "six", quantity: "x5"))
-        items.append(Items(name: "seven", quantity: "x5"))
-        items.append(Items(name: "eight", quantity: "x5"))
-        items.append(Items(name: "nine", quantity: "x5"))
-        items.append(Items(name: "ten", quantity: "x5"))
+        let itemsArr = localCharacter.itemsInInventory
+        var quantities = localCharacter.inventoryQuantities
+        for ite in itemsArr {
+            if quantities.keys.contains(ite.name) {
+                print(ite.name)
+                print(quantities[ite.name])
+                items.append(Items(name: ite.name, quantity: "x\(quantities[ite.name]!)"))
+                quantities.removeValue(forKey: ite.name)
+            }
+        }
     }
 
     func createStatsArray() {

--- a/step-strikers-app/step-strikers-app/Battle Screens/BattleSelectItemViewController.swift
+++ b/step-strikers-app/step-strikers-app/Battle Screens/BattleSelectItemViewController.swift
@@ -166,12 +166,12 @@ class BattleSelectItemViewController: UIViewController, UITableViewDataSource, U
     func createItemArray() {
         let itemsArr = localCharacter.itemsInInventory
         var quantities = localCharacter.inventoryQuantities
-        for ite in itemsArr {
-            if quantities.keys.contains(ite.name) {
-                print(ite.name)
-                print(quantities[ite.name])
-                items.append(Items(name: ite.name, quantity: "x\(quantities[ite.name]!)"))
-                quantities.removeValue(forKey: ite.name)
+        for invItem in itemsArr {
+            if quantities.keys.contains(invItem.name) {
+                print(invItem.name)
+                print(quantities[invItem.name])
+                items.append(Items(name: invItem.name, quantity: "x\(quantities[invItem.name]!)"))
+                quantities.removeValue(forKey: invItem.name)
             }
         }
     }

--- a/step-strikers-app/step-strikers-app/Battle Screens/TableViewCells/EquipTableViewCell.swift
+++ b/step-strikers-app/step-strikers-app/Battle Screens/TableViewCells/EquipTableViewCell.swift
@@ -44,7 +44,7 @@ class EquipTableViewCell: UITableViewCell {
         addSubview(equipName)
         addSubview(equipQuantity)
         // anchors the name to the left of the row
-        equipName.anchor(top: topAnchor, left: leftAnchor, bottom: bottomAnchor, right: nil, paddingTop: 5, paddingLeft: 5, paddingBottom: 5, paddingRight: 0, width: 90, height: 0, enableInsets: false)
+        equipName.anchor(top: topAnchor, left: leftAnchor, bottom: bottomAnchor, right: nil, paddingTop: 5, paddingLeft: 5, paddingBottom: 5, paddingRight: 0, width: 200, height: 0, enableInsets: false)
         // anchors the quantity based on how long the name is
         equipQuantity.anchor(top: topAnchor, left: nil, bottom: nil, right: rightAnchor, paddingTop: 5, paddingLeft: 5, paddingBottom: 5, paddingRight: 0, width: 90, height: 0, enableInsets: false)
     }

--- a/step-strikers-app/step-strikers-app/Battle Screens/TableViewCells/ItemTableViewCell.swift
+++ b/step-strikers-app/step-strikers-app/Battle Screens/TableViewCells/ItemTableViewCell.swift
@@ -41,7 +41,7 @@ class ItemTableViewCell: UITableViewCell {
         addSubview(itemName)
         addSubview(itemQuantity)
         // anchors the two strings based on their relative position within the cell and each other
-        itemName.anchor(top: topAnchor, left: leftAnchor, bottom: bottomAnchor, right: nil, paddingTop: 5, paddingLeft: 5, paddingBottom: 5, paddingRight: 0, width: 90, height: 0, enableInsets: false)
+        itemName.anchor(top: topAnchor, left: leftAnchor, bottom: bottomAnchor, right: nil, paddingTop: 5, paddingLeft: 5, paddingBottom: 5, paddingRight: 0, width: 200, height: 0, enableInsets: false)
         itemQuantity.anchor(top: topAnchor, left: nil, bottom: nil, right: rightAnchor, paddingTop: 5, paddingLeft: 5, paddingBottom: 5, paddingRight: 0, width: 90, height: 0, enableInsets: false)
     }
     


### PR DESCRIPTION
The table views in the item and equip screens for battle now reflect the items, weapons, and armor, currently in a player's inventory. Using Nick's dictionary methods - let me know if I used them wrong. 

Updated width of text box to fit long item names